### PR TITLE
Strip non-parsed left over codes

### DIFF
--- a/mqtt-notify.pl
+++ b/mqtt-notify.pl
@@ -92,6 +92,7 @@ sub sig_message_private ($$$$) {
     $body = '(PM: '.$nick.")\n".$data;
   }
   utf8::decode($body);
+  $body = Irssi::strip_codes($body);
   my @message_args = @args;
   push(@message_args, "-m", $body);
   mosquitto_pub(@message_args);
@@ -105,6 +106,7 @@ sub sig_print_text ($$$) {
   if ($dest->{level} & MSGLEVEL_HILIGHT) {
     my $body = '['.$dest->{target}."]\n".$stripped;
     utf8::decode($body);
+    $body = Irssi::strip_codes($body);
     my @message_args = @args;
     push(@message_args, "-m", $body);
     mosquitto_pub(@message_args);
@@ -139,6 +141,7 @@ sub sig_message_topic {
 
   my $body = 'Topic for '.$channel."\n".$topic;
   utf8::decode($body);
+  $body = Irssi::strip_codes($body);
   my @message_args = @args;
   push(@message_args, "-m", $body);
   mosquitto_pub(@message_args);


### PR DESCRIPTION
Happens typically when using Bitlbee with otr messages.
